### PR TITLE
workaround for "curl: (77) error setting certificate verify locations"

### DIFF
--- a/rootfs/usr/local/bin/detect-external-ip.sh
+++ b/rootfs/usr/local/bin/detect-external-ip.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ -z "$REAL_EXTERNAL_IP" ]; then
-  export REAL_EXTERNAL_IP="$(curl -4 https://icanhazip.com 2>/dev/null)"
+  export REAL_EXTERNAL_IP="$(curl -4k https://icanhazip.com 2>/dev/null)"
 fi
 
 exec echo "$REAL_EXTERNAL_IP"


### PR DESCRIPTION
workaround for "curl: (77) error setting certificate verify locations"