### PR TITLE
Use DNS requests to discover external IP address

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,10 @@ RUN apk update \
         hiredis \
         mongo-c-driver \
     \
+ # Install tools for `detect-external-ip.sh`.
+ && apk add --no-cache \
+        bind-tools \
+    \
  # Install tools for building.
  && apk add --no-cache --virtual .tool-deps \
         coreutils autoconf g++ libtool make \

--- a/rootfs/usr/local/bin/detect-external-ip.sh
+++ b/rootfs/usr/local/bin/detect-external-ip.sh
@@ -1,7 +1,112 @@
-#!/bin/sh
+#!/usr/bin/env ash
 
-if [ -z "$REAL_EXTERNAL_IP" ]; then
-  export REAL_EXTERNAL_IP="$(curl -4 https://icanhazip.com 2>/dev/null)"
+#/ Use DNS to find out about the external IP of the running system.
+#/
+#/ This script is useful when running from a machine that sits behind a NAT.
+#/ Due to how NAT works, machines behind it belong to an internal or private
+#/ subnet, with a different address space than the external or public side.
+#/
+#/ Typically it is possible to make an HTTP request to a number of providers
+#/ that offer the external IP in their response body (eg: ifconfig.me). However,
+#/ why do a slow and heavy HTTP request, when DNS exists and is much faster?
+#/ Well established providers such as OpenDNS or Google offer special hostnames
+#/ that, when resolved, will actually return the IP address of the caller.
+#/
+#/ https://unix.stackexchange.com/questions/22615/how-can-i-get-my-external-ip-address-in-a-shell-script/81699#81699
+#/
+#/
+#/ Arguments
+#/ ---------
+#/
+#/ --ipv4
+#/
+#/   Find the external IPv4 address.
+#/   Optional. Default: Enabled.
+#/
+#/ --ipv6
+#/
+#/   Find the external IPv6 address.
+#/   Optional. Default: Disabled.
+
+
+
+# Shell setup
+# ===========
+
+# Bash options for strict error checking.
+set -o errexit -o pipefail -o nounset
+
+# Trace all commands (to stderr).
+#set -o xtrace
+
+
+
+# Parse call arguments
+# ====================
+
+CFG_IPV4="true"
+
+while [ $# -gt 0 ]; do
+    case "${1-}" in
+        --ipv4) CFG_IPV4="true" ;;
+        --ipv6) CFG_IPV4="false" ;;
+        *)
+            echo "Invalid argument: '${1-}'" >&2
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+
+
+# Shortcut: REAL_EXTERNAL_IP
+# ==========================
+
+if [ -n "${REAL_EXTERNAL_IP:-}" ]; then
+    echo "$REAL_EXTERNAL_IP"
+    exit 0
 fi
 
-exec echo "$REAL_EXTERNAL_IP"
+
+
+# Discover the external IP address
+# ================================
+
+if [ "$CFG_IPV4" = "true" ]; then
+    COMMANDS='dig @resolver1.opendns.com myip.opendns.com A -4 +short
+        dig @ns1.google.com o-o.myaddr.l.google.com TXT -4 +short | tr -d \"
+        dig @1.1.1.1 whoami.cloudflare TXT CH -4 +short | tr -d \"
+        dig @ns1-1.akamaitech.net whoami.akamai.net A -4 +short'
+
+    is_valid_ip() {
+        # Check if the input looks like an IPv4 address.
+        # Doesn't check if the actual values are valid; assumes they are.
+        echo "$1" | grep -Eq '^([0-9]{1,3}\.){3}[0-9]{1,3}$'
+    }
+else
+    COMMANDS='dig @resolver1.opendns.com myip.opendns.com AAAA -6 +short
+        dig @ns1.google.com o-o.myaddr.l.google.com TXT -6 +short | tr -d \"
+        dig @2606:4700:4700::1111 whoami.cloudflare TXT CH -6 +short | tr -d \"'
+
+    is_valid_ip() {
+        # Check if the input looks like an IPv6 address.
+        # It's almost impossible to check the IPv6 representation because it
+        # varies wildly, so just check that there are at least 2 colons.
+        [ "$(echo "$1" | awk -F':' '{print NF-1}')" -ge 2 ]
+    }
+fi
+
+echo "$COMMANDS" | while read -r COMMAND; do
+    if IP="$(eval "$COMMAND")" && is_valid_ip "$IP"; then
+        echo "$IP"
+        exit 100 # Exits the pipe subshell.
+    fi
+done
+
+if [ $? -eq 100 ]; then
+    exit 0
+else
+    echo "[$0] All providers failed" >&2
+    exit 1
+fi


### PR DESCRIPTION
Using DNS requests is a much more robust and reliable method to discover
a machine's external IP address, instead of the previous method of using
Curl against an HTTP service.

Using Curl is fine, but the kind of services that are typically used
(here it was icanhazip.com, but there are lots more with a similar
behavior) are are not as dependable as the official DNS request methods
supported by some of the biggest service providers.

This uses "dig", which Alpine provides in the package "bind-tools".

This also offers IPv6 discovery, because the code is directly being adapted to Busybox's Ash from an script that I already had been using for some time: https://github.com/j1elo/shell-snippets/blob/master/discover-public-ip.sh (but if IPv6 is not desired, that part could be removed)